### PR TITLE
chore: publish API docs to GitHub Pages via amp-catalog

### DIFF
--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -1,0 +1,20 @@
+name: Publish API docs
+
+# Publishes this API's Swagger UI to https://hmcts.github.io/<repo>/ on release.
+# All the work lives in the shared catalog workflow; this repo only declares
+# where its OpenAPI spec is. See https://github.com/hmcts/amp-catalog.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    uses: hmcts/amp-catalog/.github/workflows/publish-swagger-ui.yml@v1
+    with:
+      openapi_path: src/main/resources/openapi/openapi-spec.yml

--- a/src/main/resources/openapi/openapi-spec.yml
+++ b/src/main/resources/openapi/openapi-spec.yml
@@ -1,8 +1,12 @@
 openapi: 3.0.0
 
 servers:
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/HMCTS-DTS/api-cp-refdata-courthearing-courthouses/0.0.0
+  - description: Refdata Court Hearing Court Houses API
+    url: https://api-cp-refdata-courthearing-courthouses.net/{version}
+    variables:
+      version:
+        default: 0.0.0
+        description: API version; matches the spec info.version
 
 info:
   title: Common Platform API Refdata Court Hearing Court Houses


### PR DESCRIPTION
Onboards this repo to the API Catalog stop-gap:

- Adds the single caller workflow publishing the Swagger UI for `src/main/resources/openapi/openapi-spec.yml` to https://hmcts.github.io/api-cp-refdata-courthearing-courthouses/ on release (or manual dispatch), via the shared `hmcts/amp-catalog` workflow (pinned to `@v1`).
- Replaces the stale SwaggerHub virtserver URL in the spec's `servers` block with the standard pattern `https://api-cp-refdata-courthearing-courthouses.net/{version}` (version variable matches `info.version`; re-stamped with the release version by `hmcts/update-openapi-version` at release time).