### PR TITLE
Enrich API info.description with plain English marketplace summary

### DIFF
--- a/src/main/resources/openapi/openapi-spec.yml
+++ b/src/main/resources/openapi/openapi-spec.yml
@@ -10,7 +10,13 @@ servers:
 
 info:
   title: Common Platform API Refdata Court Hearing Court Houses
-  description: Reference Data API providing information on Court Houses associated with a Court Hearing
+  description: |
+    Provides information about court buildings and the rooms within them.
+
+    Returns the building name, postal address, and room details for a given court.
+    Used by listing officers and court diary systems to show where a hearing is
+    taking place — for example when printing a hearing notice or populating a
+    daily court list.
   version: 0.0.0
   contact:
     email: no-reply@hmcts.com


### PR DESCRIPTION
## What changed
- Replaced the single-line `info.description` in `openapi-spec.yml` with a multi-paragraph plain English explanation of the court house and court room reference data returned and who uses the API

## Why it's needed
The AMP catalog front door surfaces `info.description` as the first thing a consumer sees when browsing the marketplace. The previous description gave no useful context to someone unfamiliar with the domain. The new description explains court venue details, address data, and room identifiers in business terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)